### PR TITLE
Update check_equallogic.sh

### DIFF
--- a/check_equallogic.sh
+++ b/check_equallogic.sh
@@ -64,6 +64,7 @@
 # 20131122 Bugfix in vol check when volumes spread across members              #
 # 20131219 Bugfix in poolusage check when a pool was not used (0 size)         #
 # 20140626 Bugfix in etherrors check                                           #
+# 20140711 Bugfix in disk check when hostname is not resolve name              #
 ################################################################################
 # Usage: ./check_equallogic -H host -C community -t type [-v volume] [-w warning] [-c critical]
 ################################################################################
@@ -213,6 +214,11 @@ fi
 # --- disk --- #
 disk)
 diskresult=$(snmpwalk -v 2c -O vq -c ${community} ${host} 1.3.6.1.4.1.12740.3.1.1.1.8)
+if [ -z ${diskresult} ]
+then
+   echo "UNKNOWN: check disk failed, please check your config."
+   exit ${STATE_UNKNOWN}
+fi
 diskstatusok=0
 diskstatusspare=0
 diskstatusfailed=0


### PR DESCRIPTION
This script need a connectivity check (see tatref's request )

Here is an bugfixe in check disk when name is not resolve :
- Before :
  ./check_equallogic.sh -C public -H bad_name -t disk
  getaddrinfo: bad_name Name or service not known
  snmpwalk: Unknown host (bad_name)
  DISK OK 0 disks OK 0 disks spare
- After :
  ./check_equallogic.sh -C public -H bad_name -t disk
  getaddrinfo: bad_name Name or service not known
  snmpwalk: Unknown host (bad_name)
  UNKNOWN: check disk failed, please check your config.
